### PR TITLE
ci: package test layout artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        layout: [qwerty, colemak, dvorak]
+        layout: [qwerty, colemak, dvorak, test]
         split:  [duo, trio]
 
     steps:


### PR DESCRIPTION
## Summary
- include `test` layout alongside qwerty/colemak/dvorak in packaging matrix so CI zips and uploads test duo/trio firmware

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad5b16ad108324995f8a526fa304fd