### PR TITLE
Remove secondary layout layers from base keymaps

### DIFF
--- a/config/colemak/baseform.keymap
+++ b/config/colemak/baseform.keymap
@@ -5,11 +5,10 @@
 #include <dt-bindings/zmk/outputs.h>
 
 #define COL 0
-#define QWE 1
-#define SYM 2
-#define NAV 3
-#define FUN 4
-#define MET 5
+#define SYM 1
+#define NAV 2
+#define FUN 3
+#define MET 4
 
 &lt {
   tapping-term-ms = <150>;
@@ -48,16 +47,6 @@
       >;
     };
 
-    qwerty_layer {
-      display-name = "qwerty";
-      bindings = <
-        &trans       &trans          &trans       &trans         &trans           &trans               &trans          &trans          &trans        &trans       &trans          &trans         
-        &trans       &hm RALT Q      &kp W        &kp E          &kp R            &kp T                &kp Y           &kp U           &kp I         &kp O        &kp P           &trans          
-        &trans       &kp A           &kp S        &kp D          &kp F            &kp G                &kp H           &kp J           &kp K         &kp L        &hm RALT RET    &trans    
-        &trans       &hm RCTRL Z     &kp X        &kp C          &kp V            &kp B                &kp N           &kp M           &kp COMMA     &kp DOT      &hm RCTRL APOS  &trans
-                                                  &trans         &trans           &trans               &trans          &trans          &trans     
-      >;
-    };
 
     symbols {
       display-name = "symbols";
@@ -99,7 +88,7 @@
         &trans         &soft_off      &out OUT_USB &out OUT_BLE   &none            &bt BT_CLR           &ext_power EP_TOG &trans         &trans        &none        &soft_off     &trans         
         &trans         &bt BT_SEL 0   &bt BT_SEL 1 &bt BT_SEL 2   &bt BT_SEL 3     &bt BT_SEL 4         &none             &none          &none         &none        &none         &trans     
         &trans         &studio_unlock &none        &bootloader    &sys_reset       &none                &none             &sys_reset     &bootloader   &none        &none         &trans
-                                                   &none           &tog 1           &tog 0               &trans            &trans         &none
+                                                   &none           &trans           &tog 0               &trans            &trans         &none
 
       >;
     };
@@ -113,6 +102,14 @@
     };
 
     extra3 {
+        status = "reserved";
+    };
+
+    extra4 {
+        status = "reserved";
+    };
+
+    extra5 {
         status = "reserved";
     };
 

--- a/config/dvorak/baseform.keymap
+++ b/config/dvorak/baseform.keymap
@@ -5,11 +5,10 @@
 #include <dt-bindings/zmk/outputs.h>
 
 #define DVO 0
-#define QWE 1
-#define SYM 2
-#define NAV 3
-#define FUN 4
-#define MET 5
+#define SYM 1
+#define NAV 2
+#define FUN 3
+#define MET 4
 
 &lt {
   tapping-term-ms = <150>;
@@ -48,16 +47,6 @@
       >;
     };
 
-    qwerty_layer {
-      display-name = "qwerty";
-      bindings = <
-        &trans       &trans          &trans       &trans         &trans           &trans               &trans          &trans          &trans        &trans       &trans          &trans         
-        &trans       &hm RALT Q      &kp W        &kp E          &kp R            &kp T                &kp Y           &kp U           &kp I         &kp O        &kp P           &trans          
-        &trans       &kp A           &kp S        &kp D          &kp F            &kp G                &kp H           &kp J           &kp K         &kp L        &hm RALT RET    &trans    
-        &trans       &hm RCTRL Z     &kp X        &kp C          &kp V            &kp B                &kp N           &kp M           &kp COMMA     &kp DOT      &hm RCTRL APOS  &trans
-                                                  &trans         &trans           &trans               &trans          &trans          &trans     
-      >;
-    };
 
     symbols {
       display-name = "symbols";
@@ -99,7 +88,7 @@
         &trans         &soft_off      &out OUT_USB &out OUT_BLE   &none            &bt BT_CLR           &ext_power EP_TOG &trans         &trans        &none        &soft_off     &trans         
         &trans         &bt BT_SEL 0   &bt BT_SEL 1 &bt BT_SEL 2   &bt BT_SEL 3     &bt BT_SEL 4         &none             &none          &none         &none        &none         &trans     
         &trans         &studio_unlock &none        &bootloader    &sys_reset       &none                &none             &sys_reset     &bootloader   &none        &none         &trans
-                                                   &none           &tog 1           &tog 0               &trans            &trans         &none
+                                                   &none           &trans           &tog 0               &trans            &trans         &none
 
       >;
     };
@@ -113,6 +102,14 @@
     };
 
     extra3 {
+        status = "reserved";
+    };
+
+    extra4 {
+        status = "reserved";
+    };
+
+    extra5 {
         status = "reserved";
     };
 

--- a/config/qwerty/baseform.keymap
+++ b/config/qwerty/baseform.keymap
@@ -5,11 +5,10 @@
 #include <dt-bindings/zmk/outputs.h>
 
 #define QWE 0
-#define COL 1
-#define SYM 2
-#define NAV 3
-#define FUN 4
-#define MET 5
+#define SYM 1
+#define NAV 2
+#define FUN 3
+#define MET 4
 
 &lt {
   tapping-term-ms = <150>;
@@ -48,16 +47,6 @@
       >;
     };
 
-    colemak_layer {
-      display-name = "colemak";
-      bindings = <
-        &trans      &trans         &trans       &trans         &trans           &trans               &trans         &trans          &trans        &trans       &trans          &trans         
-        &trans      &hm RALT Q     &kp W        &kp F          &kp P            &kp B                &kp J          &kp L           &kp U         &kp Y        &hm RALT APOS   &trans         
-        &trans      &kp A          &kp R        &kp S          &kp T            &kp G                &kp M          &kp N           &kp E         &kp I        &kp O           &trans    
-        &trans      &hm RCTRL Z    &kp X        &kp C          &kp D            &kp V                &kp K          &kp H           &kp COMMA     &kp DOT      &hm RCTRL RET   &trans
-                                                &trans         &trans           &trans               &trans         &trans          &trans     
-      >;
-    };
 
     symbols {
       display-name = "symbols";
@@ -99,7 +88,7 @@
         &trans         &soft_off      &out OUT_USB &out OUT_BLE   &none            &bt BT_CLR           &ext_power EP_TOG &trans         &trans        &none        &soft_off     &trans         
         &trans         &bt BT_SEL 0   &bt BT_SEL 1 &bt BT_SEL 2   &bt BT_SEL 3     &bt BT_SEL 4         &none             &none          &none         &none        &none         &trans     
         &trans         &studio_unlock &none        &bootloader    &sys_reset       &none                &none             &sys_reset     &bootloader   &none        &none         &trans
-                                                   &none           &tog 1           &tog 0               &trans            &trans         &none
+                                                   &none           &trans           &tog 0               &trans            &trans         &none
 
       >;
     };
@@ -113,6 +102,14 @@
     };
 
     extra3 {
+        status = "reserved";
+    };
+
+    extra4 {
+        status = "reserved";
+    };
+
+    extra5 {
         status = "reserved";
     };
 


### PR DESCRIPTION
## Summary
- drop alternate base layers from Colemak, Qwerty, and Dvorak keymaps
- renumber remaining layers and strip layer toggle keys
- add two reserved extra layers to each keymap for future use

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad738f23408324a76acafc03ee7884