### PR TITLE
refactor: centralize keymap edge definitions

### DIFF
--- a/config/colemak/baseform.keymap
+++ b/config/colemak/baseform.keymap
@@ -38,9 +38,9 @@
       display-name = "colemak";
       bindings = <
         ROW4
-        ROW3( &hm RALT Q &kp W &kp F &kp P &kp B    &kp J &kp L &kp U &kp Y &hm RALT APOS )
-        ROW2( &kp A &kp R &kp S &kp T &kp G    &kp M &kp N &kp E &kp I &kp O )
-        ROW1( &hm RCTRL Z &kp X &kp C &kp D &kp V    &kp K &kp H &kp COMMA &kp DOT &hm RCTRL RET )
+        ROW3( &hm RALT Q   &kp W  &kp F  &kp P  &kp B    &kp J  &kp L  &kp U     &kp Y    &hm RALT APOS )
+        ROW2( &kp A        &kp R  &kp S  &kp T  &kp G    &kp M  &kp N  &kp E     &kp I    &kp O         )
+        ROW1( &hm RCTRL Z  &kp X  &kp C  &kp D  &kp V    &kp K  &kp H  &kp COMMA &kp DOT  &hm RCTRL RET )
         THUMB_ROW
       >;
     };

--- a/config/colemak/baseform.keymap
+++ b/config/colemak/baseform.keymap
@@ -48,51 +48,54 @@
       >;
     };
 
-
     symbols {
       display-name = "symbols";
       bindings = <
-        &trans         &trans         &trans       &trans         &trans           &trans               &trans         &trans         &trans        &trans       &trans       &trans         
-        &trans         &kp PRCNT      &kp CARET    &kp GRAVE      &kp TILDE        &none                &none          &kp LT         &kp GT        &kp LBKT     &kp RBKT     &trans          
-        &trans         &kp HASH       &kp AT       &kp EXCL       &kp QMARK        &none                &kp EQUAL      &kp LPAR       &kp RPAR      &kp LBRC     &kp RBRC     &trans     
-        &trans         &none          &kp AMPS     &kp DLLR       &kp SEMI         &kp PIPE             &kp UNDER      &kp COLN       &kp FSLH      &kp BSLH     &none        &trans
-                                                   &trans         &none            &trans               &trans         &trans         &trans
+        TRANS_ROW
+        ROW_TRANS( &kp PRCNT &kp CARET &kp GRAVE &kp TILDE &none    &none &kp LT &kp GT &kp LBKT &kp RBKT )
+        ROW_TRANS( &kp HASH &kp AT &kp EXCL &kp QMARK &none    &kp EQUAL &kp LPAR &kp RPAR &kp LBRC &kp RBRC )
+        ROW_TRANS( &none &kp AMPS &kp DLLR &kp SEMI &kp PIPE    &kp UNDER &kp COLN &kp FSLH &kp BSLH &none )
+                                                   &trans         &none            &trans               &trans         &trans
+      &trans
       >;
     };
 
     navigation {
       display-name = "navigate";
       bindings = <
-        &trans         &trans         &trans       &trans         &trans           &trans               &trans         &trans         &trans        &trans       &trans        &trans    
-        &trans         &kp PRCNT      &kp KP_N7    &kp KP_N8      &kp KP_N9        &kp KP_PLUS          &kp PG_UP      &kp HOME       &kp UP        &kp END      &none         &trans          
-        &trans         &kp KP_DOT     &kp KP_N4    &kp KP_N5      &kp KP_N6        &kp KP_MINUS         &kp PG_DN      &kp LEFT       &kp DOWN      &kp RIGHT    &none         &trans     
-        &trans         &kp KP_COMMA   &kp KP_N1    &kp KP_N2      &kp KP_N3        &kp KP_MULTIPLY      &none          &kp ASTRK      &kp FSLH      &kp PLUS     &kp MINUS     &trans
+        TRANS_ROW
+        ROW_TRANS( &kp PRCNT &kp KP_N7 &kp KP_N8 &kp KP_N9 &kp KP_PLUS    &kp PG_UP &kp HOME &kp UP &kp END &none )
+        ROW_TRANS( &kp KP_DOT &kp KP_N4 &kp KP_N5 &kp KP_N6 &kp KP_MINUS    &kp PG_DN &kp LEFT &kp DOWN &kp RIGHT &none )
+        ROW_TRANS( &kp KP_COMMA &kp KP_N1 &kp KP_N2 &kp KP_N3 &kp KP_MULTIPLY    &none &kp ASTRK &kp FSLH &kp PLUS &kp MINUS )
                                                    &kp KP_EQUAL   &kp KP_N0        &kp KP_DIVIDE        &trans         &none          &trans
+      &trans
       >;
     };
 
     function {
       display-name = "function";
       bindings = <
-        &trans         &trans         &trans       &trans         &trans           &trans               &trans         &trans         &trans        &trans       &trans        &trans
-        &trans         &kp C_BRI_UP   &kp F7       &kp F8         &kp F9           &kp F10              &none          &none          &none         &none        &none         &trans         
-        &trans         &kp C_BRI_DN   &kp F4       &kp F5         &kp F6           &kp F11              &kp LNLCK     	&kp CAPS      &kp LSLCK     &kp PSCRN    &kp INS       &trans   
-        &trans         &none          &kp F1       &kp F2         &kp F3           &kp F12              &kp C_VOL_UP   &kp C_VOL_DN   &kp C_PP      &kp C_NEXT   &kp C_PREV    &trans
-                                                   &kp ESC        &trans           &trans               &none          &trans         &trans
+        TRANS_ROW
+        ROW_TRANS( &kp C_BRI_UP &kp F7 &kp F8 &kp F9 &kp F10    &none &none &none &none &none )
+        ROW_TRANS( &kp C_BRI_DN &kp F4 &kp F5 &kp F6 &kp F11    &kp LNLCK &kp CAPS &kp LSLCK &kp PSCRN &kp INS )
+        ROW_TRANS( &none &kp F1 &kp F2 &kp F3 &kp F12    &kp C_VOL_UP &kp C_VOL_DN &kp C_PP &kp C_NEXT &kp C_PREV )
+                                                    &kp ESC        &trans           &trans               &none          &trans         &trans
+      &trans
       >;
     };
 
     meta {
       display-name = "zmk";
       bindings = <
-        &trans         &trans         &trans       &trans         &trans           &trans               &trans            &trans         &trans        &trans       &trans        &trans  
-        &trans         &soft_off      &out OUT_USB &out OUT_BLE   &none            &bt BT_CLR           &ext_power EP_TOG &trans         &trans        &none        &soft_off     &trans         
-        &trans         &bt BT_SEL 0   &bt BT_SEL 1 &bt BT_SEL 2   &bt BT_SEL 3     &bt BT_SEL 4         &none             &none          &none         &none        &none         &trans     
-        &trans         &studio_unlock &none        &bootloader    &sys_reset       &none                &none             &sys_reset     &bootloader   &none        &none         &trans
-                                                   &none           &trans           &tog 0               &trans            &trans         &none
+        TRANS_ROW
+        ROW_TRANS( &soft_off &out OUT_USB &out OUT_BLE &none &bt BT_CLR    &ext_power EP_TOG &trans &trans &none &soft_off )
+        ROW_TRANS( &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4    &none &none &none &none &none )
+        ROW_TRANS( &studio_unlock &none &bootloader &sys_reset &none    &none &sys_reset &bootloader &none &none )
+                                                     &none           &trans           &tog 0               &trans            &trans         &none
 
       >;
     };
+
 
     extra1 {
         status = "reserved";

--- a/config/colemak/baseform.keymap
+++ b/config/colemak/baseform.keymap
@@ -40,10 +40,10 @@
     colemak_layer {
       display-name = "colemak";
       bindings = <
-        TOP_ROW
-        ROW2( &hm RALT Q &kp W &kp F &kp P &kp B    &kp J &kp L &kp U &kp Y &hm RALT APOS )
-        ROW3( &kp A &kp R &kp S &kp T &kp G    &kp M &kp N &kp E &kp I &kp O )
-        ROW4( &hm RCTRL Z &kp X &kp C &kp D &kp V    &kp K &kp H &kp COMMA &kp DOT &hm RCTRL RET )
+        ROW4
+        ROW3( &hm RALT Q &kp W &kp F &kp P &kp B    &kp J &kp L &kp U &kp Y &hm RALT APOS )
+        ROW2( &kp A &kp R &kp S &kp T &kp G    &kp M &kp N &kp E &kp I &kp O )
+        ROW1( &hm RCTRL Z &kp X &kp C &kp D &kp V    &kp K &kp H &kp COMMA &kp DOT &hm RCTRL RET )
         THUMB_ROW
       >;
     };

--- a/config/colemak/baseform.keymap
+++ b/config/colemak/baseform.keymap
@@ -52,9 +52,9 @@
       display-name = "symbols";
       bindings = <
         TRANS_ROW
-        ROW_TRANS( &kp PRCNT &kp CARET &kp GRAVE &kp TILDE &none    &none &kp LT &kp GT &kp LBKT &kp RBKT )
-        ROW_TRANS( &kp HASH &kp AT &kp EXCL &kp QMARK &none    &kp EQUAL &kp LPAR &kp RPAR &kp LBRC &kp RBRC )
-        ROW_TRANS( &none &kp AMPS &kp DLLR &kp SEMI &kp PIPE    &kp UNDER &kp COLN &kp FSLH &kp BSLH &none )
+        TRANS_FLANK( &kp PRCNT &kp CARET &kp GRAVE &kp TILDE &none    &none &kp LT &kp GT &kp LBKT &kp RBKT )
+        TRANS_FLANK( &kp HASH &kp AT &kp EXCL &kp QMARK &none    &kp EQUAL &kp LPAR &kp RPAR &kp LBRC &kp RBRC )
+        TRANS_FLANK( &none &kp AMPS &kp DLLR &kp SEMI &kp PIPE    &kp UNDER &kp COLN &kp FSLH &kp BSLH &none )
                                                    &trans         &none            &trans               &trans         &trans
       &trans
       >;
@@ -64,9 +64,9 @@
       display-name = "navigate";
       bindings = <
         TRANS_ROW
-        ROW_TRANS( &kp PRCNT &kp KP_N7 &kp KP_N8 &kp KP_N9 &kp KP_PLUS    &kp PG_UP &kp HOME &kp UP &kp END &none )
-        ROW_TRANS( &kp KP_DOT &kp KP_N4 &kp KP_N5 &kp KP_N6 &kp KP_MINUS    &kp PG_DN &kp LEFT &kp DOWN &kp RIGHT &none )
-        ROW_TRANS( &kp KP_COMMA &kp KP_N1 &kp KP_N2 &kp KP_N3 &kp KP_MULTIPLY    &none &kp ASTRK &kp FSLH &kp PLUS &kp MINUS )
+        TRANS_FLANK( &kp PRCNT &kp KP_N7 &kp KP_N8 &kp KP_N9 &kp KP_PLUS    &kp PG_UP &kp HOME &kp UP &kp END &none )
+        TRANS_FLANK( &kp KP_DOT &kp KP_N4 &kp KP_N5 &kp KP_N6 &kp KP_MINUS    &kp PG_DN &kp LEFT &kp DOWN &kp RIGHT &none )
+        TRANS_FLANK( &kp KP_COMMA &kp KP_N1 &kp KP_N2 &kp KP_N3 &kp KP_MULTIPLY    &none &kp ASTRK &kp FSLH &kp PLUS &kp MINUS )
                                                    &kp KP_EQUAL   &kp KP_N0        &kp KP_DIVIDE        &trans         &none          &trans
       &trans
       >;
@@ -76,9 +76,9 @@
       display-name = "function";
       bindings = <
         TRANS_ROW
-        ROW_TRANS( &kp C_BRI_UP &kp F7 &kp F8 &kp F9 &kp F10    &none &none &none &none &none )
-        ROW_TRANS( &kp C_BRI_DN &kp F4 &kp F5 &kp F6 &kp F11    &kp LNLCK &kp CAPS &kp LSLCK &kp PSCRN &kp INS )
-        ROW_TRANS( &none &kp F1 &kp F2 &kp F3 &kp F12    &kp C_VOL_UP &kp C_VOL_DN &kp C_PP &kp C_NEXT &kp C_PREV )
+        TRANS_FLANK( &kp C_BRI_UP &kp F7 &kp F8 &kp F9 &kp F10    &none &none &none &none &none )
+        TRANS_FLANK( &kp C_BRI_DN &kp F4 &kp F5 &kp F6 &kp F11    &kp LNLCK &kp CAPS &kp LSLCK &kp PSCRN &kp INS )
+        TRANS_FLANK( &none &kp F1 &kp F2 &kp F3 &kp F12    &kp C_VOL_UP &kp C_VOL_DN &kp C_PP &kp C_NEXT &kp C_PREV )
                                                     &kp ESC        &trans           &trans               &none          &trans         &trans
       &trans
       >;
@@ -88,9 +88,9 @@
       display-name = "zmk";
       bindings = <
         TRANS_ROW
-        ROW_TRANS( &soft_off &out OUT_USB &out OUT_BLE &none &bt BT_CLR    &ext_power EP_TOG &trans &trans &none &soft_off )
-        ROW_TRANS( &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4    &none &none &none &none &none )
-        ROW_TRANS( &studio_unlock &none &bootloader &sys_reset &none    &none &sys_reset &bootloader &none &none )
+        TRANS_FLANK( &soft_off &out OUT_USB &out OUT_BLE &none &bt BT_CLR    &ext_power EP_TOG &trans &trans &none &soft_off )
+        TRANS_FLANK( &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4    &none &none &none &none &none )
+        TRANS_FLANK( &studio_unlock &none &bootloader &sys_reset &none    &none &sys_reset &bootloader &none &none )
                                                      &none           &trans           &tog 0               &trans            &trans         &none
 
       >;

--- a/config/colemak/baseform.keymap
+++ b/config/colemak/baseform.keymap
@@ -3,7 +3,7 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/ext_power.h>
 #include <dt-bindings/zmk/outputs.h>
-#include "keymap_edges.dtsi"
+#include "../keymap_edges.dtsi"
 
 #define COL 0
 #define SYM 1

--- a/config/colemak/baseform.keymap
+++ b/config/colemak/baseform.keymap
@@ -41,9 +41,9 @@
       display-name = "colemak";
       bindings = <
         TOP_ROW
-        ROW2(&hm RALT Q &kp W &kp F &kp P &kp B &kp J &kp L &kp U &kp Y &hm RALT APOS)
-        ROW3(&kp A &kp R &kp S &kp T &kp G &kp M &kp N &kp E &kp I &kp O)
-        ROW4(&hm RCTRL Z &kp X &kp C &kp D &kp V &kp K &kp H &kp COMMA &kp DOT &hm RCTRL RET)
+        ROW2( &hm RALT Q &kp W &kp F &kp P &kp B    &kp J &kp L &kp U &kp Y &hm RALT APOS )
+        ROW3( &kp A &kp R &kp S &kp T &kp G    &kp M &kp N &kp E &kp I &kp O )
+        ROW4( &hm RCTRL Z &kp X &kp C &kp D &kp V    &kp K &kp H &kp COMMA &kp DOT &hm RCTRL RET )
         THUMB_ROW
       >;
     };

--- a/config/colemak/baseform.keymap
+++ b/config/colemak/baseform.keymap
@@ -3,6 +3,7 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/ext_power.h>
 #include <dt-bindings/zmk/outputs.h>
+#include "keymap_edges.dtsi"
 
 #define COL 0
 #define SYM 1
@@ -39,11 +40,11 @@
     colemak_layer {
       display-name = "colemak";
       bindings = <
-        &kp ESC      &kp N1         &kp N2       &kp N3         &kp N4           &kp N5               &kp N6         &kp N7          &kp N8        &kp N9       &kp N0          &kp BSPC          
-        &kp TAB      &hm RALT Q     &kp W        &kp F          &kp P            &kp B                &kp J          &kp L           &kp U         &kp Y        &hm RALT APOS   &kp RSHFT       
-        &kp LALT     &kp A          &kp R        &kp S          &kp T            &kp G                &kp M          &kp N           &kp E         &kp I        &kp O           &kp RALT   
-        &kp LCTRL    &hm RCTRL Z    &kp X        &kp C          &kp D            &kp V                &kp K          &kp H           &kp COMMA     &kp DOT      &hm RCTRL RET   &kp RCTRL
-                                                 &mt LGUI ESC   &lt SYM TAB      &hm LSHFT SPACE      &lt FUN RET    &lt NAV BSPC    &lt MET DEL
+        TOP_ROW
+        ROW2(&hm RALT Q &kp W &kp F &kp P &kp B &kp J &kp L &kp U &kp Y &hm RALT APOS)
+        ROW3(&kp A &kp R &kp S &kp T &kp G &kp M &kp N &kp E &kp I &kp O)
+        ROW4(&hm RCTRL Z &kp X &kp C &kp D &kp V &kp K &kp H &kp COMMA &kp DOT &hm RCTRL RET)
+        THUMB_ROW
       >;
     };
 

--- a/config/colemak/baseform.keymap
+++ b/config/colemak/baseform.keymap
@@ -3,13 +3,10 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/ext_power.h>
 #include <dt-bindings/zmk/outputs.h>
+#include "../layer_defs.dtsi"
 #include "../keymap_edges.dtsi"
 
 #define COL 0
-#define SYM 1
-#define NAV 2
-#define FUN 3
-#define MET 4
 
 &lt {
   tapping-term-ms = <150>;
@@ -47,55 +44,8 @@
         THUMB_ROW
       >;
     };
-
-    symbols {
-      display-name = "symbols";
-      bindings = <
-        TRANS_ROW
-        TRANS_FLANK( &kp PRCNT &kp CARET &kp GRAVE &kp TILDE &none    &none &kp LT &kp GT &kp LBKT &kp RBKT )
-        TRANS_FLANK( &kp HASH &kp AT &kp EXCL &kp QMARK &none    &kp EQUAL &kp LPAR &kp RPAR &kp LBRC &kp RBRC )
-        TRANS_FLANK( &none &kp AMPS &kp DLLR &kp SEMI &kp PIPE    &kp UNDER &kp COLN &kp FSLH &kp BSLH &none )
-                                                   &trans         &none            &trans               &trans         &trans
-      &trans
-      >;
-    };
-
-    navigation {
-      display-name = "navigate";
-      bindings = <
-        TRANS_ROW
-        TRANS_FLANK( &kp PRCNT &kp KP_N7 &kp KP_N8 &kp KP_N9 &kp KP_PLUS    &kp PG_UP &kp HOME &kp UP &kp END &none )
-        TRANS_FLANK( &kp KP_DOT &kp KP_N4 &kp KP_N5 &kp KP_N6 &kp KP_MINUS    &kp PG_DN &kp LEFT &kp DOWN &kp RIGHT &none )
-        TRANS_FLANK( &kp KP_COMMA &kp KP_N1 &kp KP_N2 &kp KP_N3 &kp KP_MULTIPLY    &none &kp ASTRK &kp FSLH &kp PLUS &kp MINUS )
-                                                   &kp KP_EQUAL   &kp KP_N0        &kp KP_DIVIDE        &trans         &none          &trans
-      &trans
-      >;
-    };
-
-    function {
-      display-name = "function";
-      bindings = <
-        TRANS_ROW
-        TRANS_FLANK( &kp C_BRI_UP &kp F7 &kp F8 &kp F9 &kp F10    &none &none &none &none &none )
-        TRANS_FLANK( &kp C_BRI_DN &kp F4 &kp F5 &kp F6 &kp F11    &kp LNLCK &kp CAPS &kp LSLCK &kp PSCRN &kp INS )
-        TRANS_FLANK( &none &kp F1 &kp F2 &kp F3 &kp F12    &kp C_VOL_UP &kp C_VOL_DN &kp C_PP &kp C_NEXT &kp C_PREV )
-                                                    &kp ESC        &trans           &trans               &none          &trans         &trans
-      &trans
-      >;
-    };
-
-    meta {
-      display-name = "zmk";
-      bindings = <
-        TRANS_ROW
-        TRANS_FLANK( &soft_off &out OUT_USB &out OUT_BLE &none &bt BT_CLR    &ext_power EP_TOG &trans &trans &none &soft_off )
-        TRANS_FLANK( &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4    &none &none &none &none &none )
-        TRANS_FLANK( &studio_unlock &none &bootloader &sys_reset &none    &none &sys_reset &bootloader &none &none )
-                                                     &none           &trans           &tog 0               &trans            &trans         &none
-
-      >;
-    };
-
+ 
+#include "../shared_layers.dtsi"
 
     extra1 {
         status = "reserved";

--- a/config/dvorak/baseform.keymap
+++ b/config/dvorak/baseform.keymap
@@ -3,13 +3,10 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/ext_power.h>
 #include <dt-bindings/zmk/outputs.h>
+#include "../layer_defs.dtsi"
 #include "../keymap_edges.dtsi"
 
 #define DVO 0
-#define SYM 1
-#define NAV 2
-#define FUN 3
-#define MET 4
 
 &lt {
   tapping-term-ms = <150>;
@@ -47,55 +44,8 @@
         THUMB_ROW
       >;
     };
-
-    symbols {
-      display-name = "symbols";
-      bindings = <
-        TRANS_ROW
-        TRANS_FLANK( &kp PRCNT &kp CARET &kp GRAVE &kp TILDE &none    &none &kp LT &kp GT &kp LBKT &kp RBKT )
-        TRANS_FLANK( &kp HASH &kp AT &kp EXCL &kp QMARK &none    &kp EQUAL &kp LPAR &kp RPAR &kp LBRC &kp RBRC )
-        TRANS_FLANK( &none &kp AMPS &kp DLLR &kp SEMI &kp PIPE    &kp UNDER &kp COLN &kp FSLH &kp BSLH &none )
-                                                   &trans         &none            &trans               &trans         &trans
-      &trans
-      >;
-    };
-
-    navigation {
-      display-name = "navigate";
-      bindings = <
-        TRANS_ROW
-        TRANS_FLANK( &kp PRCNT &kp KP_N7 &kp KP_N8 &kp KP_N9 &kp KP_PLUS    &kp PG_UP &kp HOME &kp UP &kp END &none )
-        TRANS_FLANK( &kp KP_DOT &kp KP_N4 &kp KP_N5 &kp KP_N6 &kp KP_MINUS    &kp PG_DN &kp LEFT &kp DOWN &kp RIGHT &none )
-        TRANS_FLANK( &kp KP_COMMA &kp KP_N1 &kp KP_N2 &kp KP_N3 &kp KP_MULTIPLY    &none &kp ASTRK &kp FSLH &kp PLUS &kp MINUS )
-                                                   &kp KP_EQUAL   &kp KP_N0        &kp KP_DIVIDE        &trans         &none          &trans
-      &trans
-      >;
-    };
-
-    function {
-      display-name = "function";
-      bindings = <
-        TRANS_ROW
-        TRANS_FLANK( &kp C_BRI_UP &kp F7 &kp F8 &kp F9 &kp F10    &none &none &none &none &none )
-        TRANS_FLANK( &kp C_BRI_DN &kp F4 &kp F5 &kp F6 &kp F11    &kp LNLCK &kp CAPS &kp LSLCK &kp PSCRN &kp INS )
-        TRANS_FLANK( &none &kp F1 &kp F2 &kp F3 &kp F12    &kp C_VOL_UP &kp C_VOL_DN &kp C_PP &kp C_NEXT &kp C_PREV )
-                                                    &kp ESC        &trans           &trans               &none          &trans         &trans
-      &trans
-      >;
-    };
-
-    meta {
-      display-name = "zmk";
-      bindings = <
-        TRANS_ROW
-        TRANS_FLANK( &soft_off &out OUT_USB &out OUT_BLE &none &bt BT_CLR    &ext_power EP_TOG &trans &trans &none &soft_off )
-        TRANS_FLANK( &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4    &none &none &none &none &none )
-        TRANS_FLANK( &studio_unlock &none &bootloader &sys_reset &none    &none &sys_reset &bootloader &none &none )
-                                                     &none           &trans           &tog 0               &trans            &trans         &none
-
-      >;
-    };
-
+ 
+#include "../shared_layers.dtsi"
 
     extra1 {
         status = "reserved";

--- a/config/dvorak/baseform.keymap
+++ b/config/dvorak/baseform.keymap
@@ -3,7 +3,7 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/ext_power.h>
 #include <dt-bindings/zmk/outputs.h>
-#include "keymap_edges.dtsi"
+#include "../keymap_edges.dtsi"
 
 #define DVO 0
 #define SYM 1

--- a/config/dvorak/baseform.keymap
+++ b/config/dvorak/baseform.keymap
@@ -41,9 +41,9 @@
       display-name = "dvorak";
       bindings = <
         TOP_ROW
-        ROW2(&hm RALT APOS &kp COMMA &kp DOT &kp P &kp Y &kp F &kp G &kp C &kp R &hm RALT L)
-        ROW3(&kp A &kp O &kp E &kp U &kp I &kp D &kp H &kp T &kp N &kp S)
-        ROW4(&hm RCTRL COLN &kp Q &kp J &kp K &kp X &kp B &kp M &kp W &kp V &hm RCTRL Z)
+        ROW2( &hm RALT APOS &kp COMMA &kp DOT &kp P &kp Y    &kp F &kp G &kp C &kp R &hm RALT L )
+        ROW3( &kp A &kp O &kp E &kp U &kp I    &kp D &kp H &kp T &kp N &kp S )
+        ROW4( &hm RCTRL COLN &kp Q &kp J &kp K &kp X    &kp B &kp M &kp W &kp V &hm RCTRL Z )
         THUMB_ROW
       >;
     };

--- a/config/dvorak/baseform.keymap
+++ b/config/dvorak/baseform.keymap
@@ -48,51 +48,54 @@
       >;
     };
 
-
     symbols {
       display-name = "symbols";
       bindings = <
-        &trans         &trans         &trans       &trans         &trans           &trans               &trans         &trans         &trans        &trans       &trans       &trans         
-        &trans         &kp PRCNT      &kp CARET    &kp GRAVE      &kp TILDE        &none                &none          &kp LT         &kp GT        &kp LBKT     &kp RBKT     &trans          
-        &trans         &kp HASH       &kp AT       &kp EXCL       &kp QMARK        &none                &kp EQUAL      &kp LPAR       &kp RPAR      &kp LBRC     &kp RBRC     &trans     
-        &trans         &none          &kp AMPS     &kp DLLR       &kp SEMI         &kp PIPE             &kp UNDER      &kp COLN       &kp FSLH      &kp BSLH     &none        &trans
-                                                   &trans         &none            &trans               &trans         &trans         &trans
+        TRANS_ROW
+        ROW_TRANS( &kp PRCNT &kp CARET &kp GRAVE &kp TILDE &none    &none &kp LT &kp GT &kp LBKT &kp RBKT )
+        ROW_TRANS( &kp HASH &kp AT &kp EXCL &kp QMARK &none    &kp EQUAL &kp LPAR &kp RPAR &kp LBRC &kp RBRC )
+        ROW_TRANS( &none &kp AMPS &kp DLLR &kp SEMI &kp PIPE    &kp UNDER &kp COLN &kp FSLH &kp BSLH &none )
+                                                   &trans         &none            &trans               &trans         &trans
+      &trans
       >;
     };
 
     navigation {
       display-name = "navigate";
       bindings = <
-        &trans         &trans         &trans       &trans         &trans           &trans               &trans         &trans         &trans        &trans       &trans        &trans    
-        &trans         &kp PRCNT      &kp KP_N7    &kp KP_N8      &kp KP_N9        &kp KP_PLUS          &kp PG_UP      &kp HOME       &kp UP        &kp END      &none         &trans          
-        &trans         &kp KP_DOT     &kp KP_N4    &kp KP_N5      &kp KP_N6        &kp KP_MINUS         &kp PG_DN      &kp LEFT       &kp DOWN      &kp RIGHT    &none         &trans     
-        &trans         &kp KP_COMMA   &kp KP_N1    &kp KP_N2      &kp KP_N3        &kp KP_MULTIPLY      &none          &kp ASTRK      &kp FSLH      &kp PLUS     &kp MINUS     &trans
+        TRANS_ROW
+        ROW_TRANS( &kp PRCNT &kp KP_N7 &kp KP_N8 &kp KP_N9 &kp KP_PLUS    &kp PG_UP &kp HOME &kp UP &kp END &none )
+        ROW_TRANS( &kp KP_DOT &kp KP_N4 &kp KP_N5 &kp KP_N6 &kp KP_MINUS    &kp PG_DN &kp LEFT &kp DOWN &kp RIGHT &none )
+        ROW_TRANS( &kp KP_COMMA &kp KP_N1 &kp KP_N2 &kp KP_N3 &kp KP_MULTIPLY    &none &kp ASTRK &kp FSLH &kp PLUS &kp MINUS )
                                                    &kp KP_EQUAL   &kp KP_N0        &kp KP_DIVIDE        &trans         &none          &trans
+      &trans
       >;
     };
 
     function {
       display-name = "function";
       bindings = <
-        &trans         &trans         &trans       &trans         &trans           &trans               &trans         &trans         &trans        &trans       &trans        &trans
-        &trans         &kp C_BRI_UP   &kp F7       &kp F8         &kp F9           &kp F10              &none          &none          &none         &none        &none         &trans         
-        &trans         &kp C_BRI_DN   &kp F4       &kp F5         &kp F6           &kp F11              &kp LNLCK     	&kp CAPS      &kp LSLCK     &kp PSCRN    &kp INS       &trans   
-        &trans         &none          &kp F1       &kp F2         &kp F3           &kp F12              &kp C_VOL_UP   &kp C_VOL_DN   &kp C_PP      &kp C_NEXT   &kp C_PREV    &trans
-                                                   &kp ESC        &trans           &trans               &none          &trans         &trans
+        TRANS_ROW
+        ROW_TRANS( &kp C_BRI_UP &kp F7 &kp F8 &kp F9 &kp F10    &none &none &none &none &none )
+        ROW_TRANS( &kp C_BRI_DN &kp F4 &kp F5 &kp F6 &kp F11    &kp LNLCK &kp CAPS &kp LSLCK &kp PSCRN &kp INS )
+        ROW_TRANS( &none &kp F1 &kp F2 &kp F3 &kp F12    &kp C_VOL_UP &kp C_VOL_DN &kp C_PP &kp C_NEXT &kp C_PREV )
+                                                    &kp ESC        &trans           &trans               &none          &trans         &trans
+      &trans
       >;
     };
 
     meta {
       display-name = "zmk";
       bindings = <
-        &trans         &trans         &trans       &trans         &trans           &trans               &trans            &trans         &trans        &trans       &trans        &trans  
-        &trans         &soft_off      &out OUT_USB &out OUT_BLE   &none            &bt BT_CLR           &ext_power EP_TOG &trans         &trans        &none        &soft_off     &trans         
-        &trans         &bt BT_SEL 0   &bt BT_SEL 1 &bt BT_SEL 2   &bt BT_SEL 3     &bt BT_SEL 4         &none             &none          &none         &none        &none         &trans     
-        &trans         &studio_unlock &none        &bootloader    &sys_reset       &none                &none             &sys_reset     &bootloader   &none        &none         &trans
-                                                   &none           &trans           &tog 0               &trans            &trans         &none
+        TRANS_ROW
+        ROW_TRANS( &soft_off &out OUT_USB &out OUT_BLE &none &bt BT_CLR    &ext_power EP_TOG &trans &trans &none &soft_off )
+        ROW_TRANS( &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4    &none &none &none &none &none )
+        ROW_TRANS( &studio_unlock &none &bootloader &sys_reset &none    &none &sys_reset &bootloader &none &none )
+                                                     &none           &trans           &tog 0               &trans            &trans         &none
 
       >;
     };
+
 
     extra1 {
         status = "reserved";

--- a/config/dvorak/baseform.keymap
+++ b/config/dvorak/baseform.keymap
@@ -3,6 +3,7 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/ext_power.h>
 #include <dt-bindings/zmk/outputs.h>
+#include "keymap_edges.dtsi"
 
 #define DVO 0
 #define SYM 1
@@ -39,11 +40,11 @@
     dvorak_layer {
       display-name = "dvorak";
       bindings = <
-        &kp ESC     &kp N1         &kp N2       &kp N3         &kp N4           &kp N5               &kp N6         &kp N7          &kp N8        &kp N9       &kp N0          &kp BSPC         
-        &kp TAB     &hm RALT APOS  &kp COMMA    &kp DOT        &kp P            &kp Y                &kp F          &kp G           &kp C         &kp R        &hm RALT L      &kp RSHFT         
-        &kp LALT    &kp A          &kp O        &kp E          &kp U            &kp I                &kp D          &kp H           &kp T         &kp N        &kp S           &kp RALT     
-        &kp LCTRL   &hm RCTRL COLN &kp Q        &kp J          &kp K            &kp X                &kp B          &kp M           &kp W         &kp V        &hm RCTRL Z     &kp RCTRL
-                                                &mt LGUI ESC   &lt SYM TAB      &hm LSHFT SPACE      &lt FUN RET    &lt NAV BSPC    &lt MET DEL
+        TOP_ROW
+        ROW2(&hm RALT APOS &kp COMMA &kp DOT &kp P &kp Y &kp F &kp G &kp C &kp R &hm RALT L)
+        ROW3(&kp A &kp O &kp E &kp U &kp I &kp D &kp H &kp T &kp N &kp S)
+        ROW4(&hm RCTRL COLN &kp Q &kp J &kp K &kp X &kp B &kp M &kp W &kp V &hm RCTRL Z)
+        THUMB_ROW
       >;
     };
 

--- a/config/dvorak/baseform.keymap
+++ b/config/dvorak/baseform.keymap
@@ -52,9 +52,9 @@
       display-name = "symbols";
       bindings = <
         TRANS_ROW
-        ROW_TRANS( &kp PRCNT &kp CARET &kp GRAVE &kp TILDE &none    &none &kp LT &kp GT &kp LBKT &kp RBKT )
-        ROW_TRANS( &kp HASH &kp AT &kp EXCL &kp QMARK &none    &kp EQUAL &kp LPAR &kp RPAR &kp LBRC &kp RBRC )
-        ROW_TRANS( &none &kp AMPS &kp DLLR &kp SEMI &kp PIPE    &kp UNDER &kp COLN &kp FSLH &kp BSLH &none )
+        TRANS_FLANK( &kp PRCNT &kp CARET &kp GRAVE &kp TILDE &none    &none &kp LT &kp GT &kp LBKT &kp RBKT )
+        TRANS_FLANK( &kp HASH &kp AT &kp EXCL &kp QMARK &none    &kp EQUAL &kp LPAR &kp RPAR &kp LBRC &kp RBRC )
+        TRANS_FLANK( &none &kp AMPS &kp DLLR &kp SEMI &kp PIPE    &kp UNDER &kp COLN &kp FSLH &kp BSLH &none )
                                                    &trans         &none            &trans               &trans         &trans
       &trans
       >;
@@ -64,9 +64,9 @@
       display-name = "navigate";
       bindings = <
         TRANS_ROW
-        ROW_TRANS( &kp PRCNT &kp KP_N7 &kp KP_N8 &kp KP_N9 &kp KP_PLUS    &kp PG_UP &kp HOME &kp UP &kp END &none )
-        ROW_TRANS( &kp KP_DOT &kp KP_N4 &kp KP_N5 &kp KP_N6 &kp KP_MINUS    &kp PG_DN &kp LEFT &kp DOWN &kp RIGHT &none )
-        ROW_TRANS( &kp KP_COMMA &kp KP_N1 &kp KP_N2 &kp KP_N3 &kp KP_MULTIPLY    &none &kp ASTRK &kp FSLH &kp PLUS &kp MINUS )
+        TRANS_FLANK( &kp PRCNT &kp KP_N7 &kp KP_N8 &kp KP_N9 &kp KP_PLUS    &kp PG_UP &kp HOME &kp UP &kp END &none )
+        TRANS_FLANK( &kp KP_DOT &kp KP_N4 &kp KP_N5 &kp KP_N6 &kp KP_MINUS    &kp PG_DN &kp LEFT &kp DOWN &kp RIGHT &none )
+        TRANS_FLANK( &kp KP_COMMA &kp KP_N1 &kp KP_N2 &kp KP_N3 &kp KP_MULTIPLY    &none &kp ASTRK &kp FSLH &kp PLUS &kp MINUS )
                                                    &kp KP_EQUAL   &kp KP_N0        &kp KP_DIVIDE        &trans         &none          &trans
       &trans
       >;
@@ -76,9 +76,9 @@
       display-name = "function";
       bindings = <
         TRANS_ROW
-        ROW_TRANS( &kp C_BRI_UP &kp F7 &kp F8 &kp F9 &kp F10    &none &none &none &none &none )
-        ROW_TRANS( &kp C_BRI_DN &kp F4 &kp F5 &kp F6 &kp F11    &kp LNLCK &kp CAPS &kp LSLCK &kp PSCRN &kp INS )
-        ROW_TRANS( &none &kp F1 &kp F2 &kp F3 &kp F12    &kp C_VOL_UP &kp C_VOL_DN &kp C_PP &kp C_NEXT &kp C_PREV )
+        TRANS_FLANK( &kp C_BRI_UP &kp F7 &kp F8 &kp F9 &kp F10    &none &none &none &none &none )
+        TRANS_FLANK( &kp C_BRI_DN &kp F4 &kp F5 &kp F6 &kp F11    &kp LNLCK &kp CAPS &kp LSLCK &kp PSCRN &kp INS )
+        TRANS_FLANK( &none &kp F1 &kp F2 &kp F3 &kp F12    &kp C_VOL_UP &kp C_VOL_DN &kp C_PP &kp C_NEXT &kp C_PREV )
                                                     &kp ESC        &trans           &trans               &none          &trans         &trans
       &trans
       >;
@@ -88,9 +88,9 @@
       display-name = "zmk";
       bindings = <
         TRANS_ROW
-        ROW_TRANS( &soft_off &out OUT_USB &out OUT_BLE &none &bt BT_CLR    &ext_power EP_TOG &trans &trans &none &soft_off )
-        ROW_TRANS( &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4    &none &none &none &none &none )
-        ROW_TRANS( &studio_unlock &none &bootloader &sys_reset &none    &none &sys_reset &bootloader &none &none )
+        TRANS_FLANK( &soft_off &out OUT_USB &out OUT_BLE &none &bt BT_CLR    &ext_power EP_TOG &trans &trans &none &soft_off )
+        TRANS_FLANK( &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4    &none &none &none &none &none )
+        TRANS_FLANK( &studio_unlock &none &bootloader &sys_reset &none    &none &sys_reset &bootloader &none &none )
                                                      &none           &trans           &tog 0               &trans            &trans         &none
 
       >;

--- a/config/dvorak/baseform.keymap
+++ b/config/dvorak/baseform.keymap
@@ -40,10 +40,10 @@
     dvorak_layer {
       display-name = "dvorak";
       bindings = <
-        TOP_ROW
-        ROW2( &hm RALT APOS &kp COMMA &kp DOT &kp P &kp Y    &kp F &kp G &kp C &kp R &hm RALT L )
-        ROW3( &kp A &kp O &kp E &kp U &kp I    &kp D &kp H &kp T &kp N &kp S )
-        ROW4( &hm RCTRL COLN &kp Q &kp J &kp K &kp X    &kp B &kp M &kp W &kp V &hm RCTRL Z )
+        ROW4
+        ROW3( &hm RALT APOS &kp COMMA &kp DOT &kp P &kp Y    &kp F &kp G &kp C &kp R &hm RALT L )
+        ROW2( &kp A &kp O &kp E &kp U &kp I    &kp D &kp H &kp T &kp N &kp S )
+        ROW1( &hm RCTRL COLN &kp Q &kp J &kp K &kp X    &kp B &kp M &kp W &kp V &hm RCTRL Z )
         THUMB_ROW
       >;
     };

--- a/config/dvorak/baseform.keymap
+++ b/config/dvorak/baseform.keymap
@@ -38,9 +38,9 @@
       display-name = "dvorak";
       bindings = <
         ROW4
-        ROW3( &hm RALT APOS &kp COMMA &kp DOT &kp P &kp Y    &kp F &kp G &kp C &kp R &hm RALT L )
-        ROW2( &kp A &kp O &kp E &kp U &kp I    &kp D &kp H &kp T &kp N &kp S )
-        ROW1( &hm RCTRL COLN &kp Q &kp J &kp K &kp X    &kp B &kp M &kp W &kp V &hm RCTRL Z )
+        ROW3( &hm RALT APOS   &kp COMMA  &kp DOT  &kp P  &kp Y    &kp F  &kp G  &kp C  &kp R  &hm RALT L  )
+        ROW2( &kp A           &kp O      &kp E    &kp U  &kp I    &kp D  &kp H  &kp T  &kp N  &kp S       )
+        ROW1( &hm RCTRL COLN  &kp Q      &kp J    &kp K  &kp X    &kp B  &kp M  &kp W  &kp V  &hm RCTRL Z )
         THUMB_ROW
       >;
     };

--- a/config/keymap_edges.dtsi
+++ b/config/keymap_edges.dtsi
@@ -1,12 +1,12 @@
-#define TOP_ROW \
+#define ROW4 \
     &kp ESC &kp N1 &kp N2 &kp N3 &kp N4 &kp N5    &kp N6 &kp N7 &kp N8 &kp N9 &kp N0 &kp BSPC
 
 #define THUMB_ROW \
     &mt LGUI ESC &lt SYM TAB &hm LSHFT SPACE    &lt FUN RET &lt NAV BSPC &lt MET DEL
 
-#define ROW2(...) &kp TAB __VA_ARGS__ &kp RSHFT
-#define ROW3(...) &kp LALT __VA_ARGS__ &kp RALT
-#define ROW4(...) &kp LCTRL __VA_ARGS__ &kp RCTRL
+#define ROW3(...) &kp TAB __VA_ARGS__ &kp RSHFT
+#define ROW2(...) &kp LALT __VA_ARGS__ &kp RALT
+#define ROW1(...) &kp LCTRL __VA_ARGS__ &kp RCTRL
 
 #define TRANS_ROW \
     &trans &trans &trans &trans &trans    &trans &trans &trans &trans &trans &trans &trans

--- a/config/keymap_edges.dtsi
+++ b/config/keymap_edges.dtsi
@@ -11,5 +11,5 @@
 #define TRANS_ROW \
     &trans &trans &trans &trans &trans    &trans &trans &trans &trans &trans &trans &trans
 
-#define ROW_TRANS(...) &trans __VA_ARGS__ &trans
+#define TRANS_FLANK(...) &trans __VA_ARGS__ &trans
 

--- a/config/keymap_edges.dtsi
+++ b/config/keymap_edges.dtsi
@@ -1,15 +1,15 @@
 #define ROW4 \
     &kp ESC &kp N1 &kp N2 &kp N3 &kp N4 &kp N5    &kp N6 &kp N7 &kp N8 &kp N9 &kp N0 &kp BSPC
 
-#define THUMB_ROW \
-    &mt LGUI ESC &lt SYM TAB &hm LSHFT SPACE    &lt FUN RET &lt NAV BSPC &lt MET DEL
-
-#define ROW3(...) &kp TAB __VA_ARGS__ &kp RSHFT
-#define ROW2(...) &kp LALT __VA_ARGS__ &kp RALT
+#define ROW3(...) &kp TAB   __VA_ARGS__ &kp RSHFT
+#define ROW2(...) &kp LALT  __VA_ARGS__ &kp RALT
 #define ROW1(...) &kp LCTRL __VA_ARGS__ &kp RCTRL
 
+#define THUMB_ROW \
+    &mt LGUI ESC &lt SYM TAB &hm LSHFT SPACE      &lt FUN RET &lt NAV BSPC &lt MET DEL
+
 #define TRANS_ROW \
-    &trans &trans &trans &trans &trans    &trans &trans &trans &trans &trans &trans &trans
+    &trans &trans &trans &trans &trans &trans     &trans &trans &trans &trans &trans &trans
 
 #define TRANS_FLANK(...) &trans __VA_ARGS__ &trans
 

--- a/config/keymap_edges.dtsi
+++ b/config/keymap_edges.dtsi
@@ -1,0 +1,10 @@
+#define TOP_ROW \
+    &kp ESC &kp N1 &kp N2 &kp N3 &kp N4 &kp N5 &kp N6 &kp N7 \
+    &kp N8 &kp N9 &kp N0 &kp BSPC
+
+#define THUMB_ROW \
+    &mt LGUI ESC &lt SYM TAB &hm LSHFT SPACE &lt FUN RET &lt NAV BSPC &lt MET DEL
+
+#define ROW2(...) &kp TAB __VA_ARGS__ &kp RSHFT
+#define ROW3(...) &kp LALT __VA_ARGS__ &kp RALT
+#define ROW4(...) &kp LCTRL __VA_ARGS__ &kp RCTRL

--- a/config/keymap_edges.dtsi
+++ b/config/keymap_edges.dtsi
@@ -1,10 +1,10 @@
 #define TOP_ROW \
-    &kp ESC &kp N1 &kp N2 &kp N3 &kp N4 &kp N5 &kp N6 &kp N7 \
-    &kp N8 &kp N9 &kp N0 &kp BSPC
+    &kp ESC &kp N1 &kp N2 &kp N3 &kp N4 &kp N5    &kp N6 &kp N7 &kp N8 &kp N9 &kp N0 &kp BSPC
 
 #define THUMB_ROW \
-    &mt LGUI ESC &lt SYM TAB &hm LSHFT SPACE &lt FUN RET &lt NAV BSPC &lt MET DEL
+    &mt LGUI ESC &lt SYM TAB &hm LSHFT SPACE    &lt FUN RET &lt NAV BSPC &lt MET DEL
 
 #define ROW2(...) &kp TAB __VA_ARGS__ &kp RSHFT
 #define ROW3(...) &kp LALT __VA_ARGS__ &kp RALT
 #define ROW4(...) &kp LCTRL __VA_ARGS__ &kp RCTRL
+

--- a/config/keymap_edges.dtsi
+++ b/config/keymap_edges.dtsi
@@ -8,3 +8,8 @@
 #define ROW3(...) &kp LALT __VA_ARGS__ &kp RALT
 #define ROW4(...) &kp LCTRL __VA_ARGS__ &kp RCTRL
 
+#define TRANS_ROW \
+    &trans &trans &trans &trans &trans    &trans &trans &trans &trans &trans &trans &trans
+
+#define ROW_TRANS(...) &trans __VA_ARGS__ &trans
+

--- a/config/layer_defs.dtsi
+++ b/config/layer_defs.dtsi
@@ -1,0 +1,5 @@
+#define SYM 1
+#define NAV 2
+#define FUN 3
+#define MET 4
+

--- a/config/qwerty/baseform.keymap
+++ b/config/qwerty/baseform.keymap
@@ -41,9 +41,9 @@
       display-name = "qwerty";
       bindings = <
         TOP_ROW
-        ROW2(&hm RALT Q &kp W &kp E &kp R &kp T &kp Y &kp U &kp I &kp O &kp P)
-        ROW3(&kp A &kp S &kp D &kp F &kp G &kp H &kp J &kp K &kp L &hm RALT RET)
-        ROW4(&hm RCTRL Z &kp X &kp C &kp V &kp B &kp N &kp M &kp COMMA &kp DOT &hm RCTRL APOS)
+        ROW2( &hm RALT Q &kp W &kp E &kp R &kp T    &kp Y &kp U &kp I &kp O &kp P )
+        ROW3( &kp A &kp S &kp D &kp F &kp G    &kp H &kp J &kp K &kp L &hm RALT RET )
+        ROW4( &hm RCTRL Z &kp X &kp C &kp V &kp B    &kp N &kp M &kp COMMA &kp DOT &hm RCTRL APOS )
         THUMB_ROW
       >;
     };

--- a/config/qwerty/baseform.keymap
+++ b/config/qwerty/baseform.keymap
@@ -3,13 +3,10 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/ext_power.h>
 #include <dt-bindings/zmk/outputs.h>
+#include "../layer_defs.dtsi"
 #include "../keymap_edges.dtsi"
 
 #define QWE 0
-#define SYM 1
-#define NAV 2
-#define FUN 3
-#define MET 4
 
 &lt {
   tapping-term-ms = <150>;
@@ -47,55 +44,8 @@
         THUMB_ROW
       >;
     };
-
-    symbols {
-      display-name = "symbols";
-      bindings = <
-        TRANS_ROW
-        TRANS_FLANK( &kp PRCNT &kp CARET &kp GRAVE &kp TILDE &none    &none &kp LT &kp GT &kp LBKT &kp RBKT )
-        TRANS_FLANK( &kp HASH &kp AT &kp EXCL &kp QMARK &none    &kp EQUAL &kp LPAR &kp RPAR &kp LBRC &kp RBRC )
-        TRANS_FLANK( &none &kp AMPS &kp DLLR &kp SEMI &kp PIPE    &kp UNDER &kp COLN &kp FSLH &kp BSLH &none )
-                                                   &trans         &none            &trans               &trans         &trans
-      &trans
-      >;
-    };
-
-    navigation {
-      display-name = "navigate";
-      bindings = <
-        TRANS_ROW
-        TRANS_FLANK( &kp PRCNT &kp KP_N7 &kp KP_N8 &kp KP_N9 &kp KP_PLUS    &kp PG_UP &kp HOME &kp UP &kp END &none )
-        TRANS_FLANK( &kp KP_DOT &kp KP_N4 &kp KP_N5 &kp KP_N6 &kp KP_MINUS    &kp PG_DN &kp LEFT &kp DOWN &kp RIGHT &none )
-        TRANS_FLANK( &kp KP_COMMA &kp KP_N1 &kp KP_N2 &kp KP_N3 &kp KP_MULTIPLY    &none &kp ASTRK &kp FSLH &kp PLUS &kp MINUS )
-                                                   &kp KP_EQUAL   &kp KP_N0        &kp KP_DIVIDE        &trans         &none          &trans
-      &trans
-      >;
-    };
-
-    function {
-      display-name = "function";
-      bindings = <
-        TRANS_ROW
-        TRANS_FLANK( &kp C_BRI_UP &kp F7 &kp F8 &kp F9 &kp F10    &none &none &none &none &none )
-        TRANS_FLANK( &kp C_BRI_DN &kp F4 &kp F5 &kp F6 &kp F11    &kp LNLCK &kp CAPS &kp LSLCK &kp PSCRN &kp INS )
-        TRANS_FLANK( &none &kp F1 &kp F2 &kp F3 &kp F12    &kp C_VOL_UP &kp C_VOL_DN &kp C_PP &kp C_NEXT &kp C_PREV )
-                                                    &kp ESC        &trans           &trans               &none          &trans         &trans
-      &trans
-      >;
-    };
-
-    meta {
-      display-name = "zmk";
-      bindings = <
-        TRANS_ROW
-        TRANS_FLANK( &soft_off &out OUT_USB &out OUT_BLE &none &bt BT_CLR    &ext_power EP_TOG &trans &trans &none &soft_off )
-        TRANS_FLANK( &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4    &none &none &none &none &none )
-        TRANS_FLANK( &studio_unlock &none &bootloader &sys_reset &none    &none &sys_reset &bootloader &none &none )
-                                                     &none           &trans           &tog 0               &trans            &trans         &none
-
-      >;
-    };
-
+ 
+#include "../shared_layers.dtsi"
 
     extra1 {
         status = "reserved";

--- a/config/qwerty/baseform.keymap
+++ b/config/qwerty/baseform.keymap
@@ -38,9 +38,9 @@
       display-name = "qwerty";
       bindings = <
         ROW4
-        ROW3( &hm RALT Q &kp W &kp E &kp R &kp T    &kp Y &kp U &kp I &kp O &kp P )
-        ROW2( &kp A &kp S &kp D &kp F &kp G    &kp H &kp J &kp K &kp L &hm RALT RET )
-        ROW1( &hm RCTRL Z &kp X &kp C &kp V &kp B    &kp N &kp M &kp COMMA &kp DOT &hm RCTRL APOS )
+        ROW3( &hm RALT Q   &kp W  &kp E  &kp R  &kp T    &kp Y  &kp U  &kp I      &kp O    &kp P          )
+        ROW2( &kp A        &kp S  &kp D  &kp F  &kp G    &kp H  &kp J  &kp K      &kp L    &hm RALT RET   )
+        ROW1( &hm RCTRL Z  &kp X  &kp C  &kp V  &kp B    &kp N  &kp M  &kp COMMA  &kp DOT  &hm RCTRL APOS )
         THUMB_ROW
       >;
     };

--- a/config/qwerty/baseform.keymap
+++ b/config/qwerty/baseform.keymap
@@ -3,6 +3,7 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/ext_power.h>
 #include <dt-bindings/zmk/outputs.h>
+#include "keymap_edges.dtsi"
 
 #define QWE 0
 #define SYM 1
@@ -39,11 +40,11 @@
     qwerty_layer {
       display-name = "qwerty";
       bindings = <
-        &kp ESC        &kp N1          &kp N2       &kp N3         &kp N4           &kp N5               &kp N6          &kp N7          &kp N8        &kp N9       &kp N0          &kp BSPC         
-        &kp TAB        &hm RALT Q      &kp W        &kp E          &kp R            &kp T                &kp Y           &kp U           &kp I         &kp O        &kp P           &kp RSHFT          
-        &kp LALT       &kp A           &kp S        &kp D          &kp F            &kp G                &kp H           &kp J           &kp K         &kp L        &hm RALT RET    &kp RALT     
-        &kp LCTRL      &hm RCTRL Z     &kp X        &kp C          &kp V            &kp B                &kp N           &kp M           &kp COMMA     &kp DOT      &hm RCTRL APOS  &kp RCTRL
-                                                    &mt LGUI ESC   &lt SYM TAB      &hm LSHFT SPACE      &lt FUN RET     &lt NAV BSPC    &lt MET DEL
+        TOP_ROW
+        ROW2(&hm RALT Q &kp W &kp E &kp R &kp T &kp Y &kp U &kp I &kp O &kp P)
+        ROW3(&kp A &kp S &kp D &kp F &kp G &kp H &kp J &kp K &kp L &hm RALT RET)
+        ROW4(&hm RCTRL Z &kp X &kp C &kp V &kp B &kp N &kp M &kp COMMA &kp DOT &hm RCTRL APOS)
+        THUMB_ROW
       >;
     };
 

--- a/config/qwerty/baseform.keymap
+++ b/config/qwerty/baseform.keymap
@@ -48,51 +48,54 @@
       >;
     };
 
-
     symbols {
       display-name = "symbols";
       bindings = <
-        &trans         &trans         &trans       &trans         &trans           &trans               &trans         &trans         &trans        &trans       &trans       &trans         
-        &trans         &kp PRCNT      &kp CARET    &kp GRAVE      &kp TILDE        &none                &none          &kp LT         &kp GT        &kp LBKT     &kp RBKT     &trans          
-        &trans         &kp HASH       &kp AT       &kp EXCL       &kp QMARK        &none                &kp EQUAL      &kp LPAR       &kp RPAR      &kp LBRC     &kp RBRC     &trans     
-        &trans         &none          &kp AMPS     &kp DLLR       &kp SEMI         &kp PIPE             &kp UNDER      &kp COLN       &kp FSLH      &kp BSLH     &none        &trans
-                                                   &trans         &none            &trans               &trans         &trans         &trans
+        TRANS_ROW
+        ROW_TRANS( &kp PRCNT &kp CARET &kp GRAVE &kp TILDE &none    &none &kp LT &kp GT &kp LBKT &kp RBKT )
+        ROW_TRANS( &kp HASH &kp AT &kp EXCL &kp QMARK &none    &kp EQUAL &kp LPAR &kp RPAR &kp LBRC &kp RBRC )
+        ROW_TRANS( &none &kp AMPS &kp DLLR &kp SEMI &kp PIPE    &kp UNDER &kp COLN &kp FSLH &kp BSLH &none )
+                                                   &trans         &none            &trans               &trans         &trans
+      &trans
       >;
     };
 
     navigation {
       display-name = "navigate";
       bindings = <
-        &trans         &trans         &trans       &trans         &trans           &trans               &trans         &trans         &trans        &trans       &trans        &trans    
-        &trans         &kp PRCNT      &kp KP_N7    &kp KP_N8      &kp KP_N9        &kp KP_PLUS          &kp PG_UP      &kp HOME       &kp UP        &kp END      &none         &trans          
-        &trans         &kp KP_DOT     &kp KP_N4    &kp KP_N5      &kp KP_N6        &kp KP_MINUS         &kp PG_DN      &kp LEFT       &kp DOWN      &kp RIGHT    &none         &trans     
-        &trans         &kp KP_COMMA   &kp KP_N1    &kp KP_N2      &kp KP_N3        &kp KP_MULTIPLY      &none          &kp ASTRK      &kp FSLH      &kp PLUS     &kp MINUS     &trans
+        TRANS_ROW
+        ROW_TRANS( &kp PRCNT &kp KP_N7 &kp KP_N8 &kp KP_N9 &kp KP_PLUS    &kp PG_UP &kp HOME &kp UP &kp END &none )
+        ROW_TRANS( &kp KP_DOT &kp KP_N4 &kp KP_N5 &kp KP_N6 &kp KP_MINUS    &kp PG_DN &kp LEFT &kp DOWN &kp RIGHT &none )
+        ROW_TRANS( &kp KP_COMMA &kp KP_N1 &kp KP_N2 &kp KP_N3 &kp KP_MULTIPLY    &none &kp ASTRK &kp FSLH &kp PLUS &kp MINUS )
                                                    &kp KP_EQUAL   &kp KP_N0        &kp KP_DIVIDE        &trans         &none          &trans
+      &trans
       >;
     };
 
     function {
       display-name = "function";
       bindings = <
-        &trans         &trans         &trans       &trans         &trans           &trans               &trans         &trans         &trans        &trans       &trans        &trans
-        &trans         &kp C_BRI_UP   &kp F7       &kp F8         &kp F9           &kp F10              &none          &none          &none         &none        &none         &trans         
-        &trans         &kp C_BRI_DN   &kp F4       &kp F5         &kp F6           &kp F11              &kp LNLCK     	&kp CAPS      &kp LSLCK     &kp PSCRN    &kp INS       &trans   
-        &trans         &none          &kp F1       &kp F2         &kp F3           &kp F12              &kp C_VOL_UP   &kp C_VOL_DN   &kp C_PP      &kp C_NEXT   &kp C_PREV    &trans
-                                                   &kp ESC        &trans           &trans               &none          &trans         &trans
+        TRANS_ROW
+        ROW_TRANS( &kp C_BRI_UP &kp F7 &kp F8 &kp F9 &kp F10    &none &none &none &none &none )
+        ROW_TRANS( &kp C_BRI_DN &kp F4 &kp F5 &kp F6 &kp F11    &kp LNLCK &kp CAPS &kp LSLCK &kp PSCRN &kp INS )
+        ROW_TRANS( &none &kp F1 &kp F2 &kp F3 &kp F12    &kp C_VOL_UP &kp C_VOL_DN &kp C_PP &kp C_NEXT &kp C_PREV )
+                                                    &kp ESC        &trans           &trans               &none          &trans         &trans
+      &trans
       >;
     };
 
     meta {
       display-name = "zmk";
       bindings = <
-        &trans         &trans         &trans       &trans         &trans           &trans               &trans            &trans         &trans        &trans       &trans        &trans  
-        &trans         &soft_off      &out OUT_USB &out OUT_BLE   &none            &bt BT_CLR           &ext_power EP_TOG &trans         &trans        &none        &soft_off     &trans         
-        &trans         &bt BT_SEL 0   &bt BT_SEL 1 &bt BT_SEL 2   &bt BT_SEL 3     &bt BT_SEL 4         &none             &none          &none         &none        &none         &trans     
-        &trans         &studio_unlock &none        &bootloader    &sys_reset       &none                &none             &sys_reset     &bootloader   &none        &none         &trans
-                                                   &none           &trans           &tog 0               &trans            &trans         &none
+        TRANS_ROW
+        ROW_TRANS( &soft_off &out OUT_USB &out OUT_BLE &none &bt BT_CLR    &ext_power EP_TOG &trans &trans &none &soft_off )
+        ROW_TRANS( &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4    &none &none &none &none &none )
+        ROW_TRANS( &studio_unlock &none &bootloader &sys_reset &none    &none &sys_reset &bootloader &none &none )
+                                                     &none           &trans           &tog 0               &trans            &trans         &none
 
       >;
     };
+
 
     extra1 {
         status = "reserved";

--- a/config/qwerty/baseform.keymap
+++ b/config/qwerty/baseform.keymap
@@ -3,7 +3,7 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/ext_power.h>
 #include <dt-bindings/zmk/outputs.h>
-#include "keymap_edges.dtsi"
+#include "../keymap_edges.dtsi"
 
 #define QWE 0
 #define SYM 1

--- a/config/qwerty/baseform.keymap
+++ b/config/qwerty/baseform.keymap
@@ -52,9 +52,9 @@
       display-name = "symbols";
       bindings = <
         TRANS_ROW
-        ROW_TRANS( &kp PRCNT &kp CARET &kp GRAVE &kp TILDE &none    &none &kp LT &kp GT &kp LBKT &kp RBKT )
-        ROW_TRANS( &kp HASH &kp AT &kp EXCL &kp QMARK &none    &kp EQUAL &kp LPAR &kp RPAR &kp LBRC &kp RBRC )
-        ROW_TRANS( &none &kp AMPS &kp DLLR &kp SEMI &kp PIPE    &kp UNDER &kp COLN &kp FSLH &kp BSLH &none )
+        TRANS_FLANK( &kp PRCNT &kp CARET &kp GRAVE &kp TILDE &none    &none &kp LT &kp GT &kp LBKT &kp RBKT )
+        TRANS_FLANK( &kp HASH &kp AT &kp EXCL &kp QMARK &none    &kp EQUAL &kp LPAR &kp RPAR &kp LBRC &kp RBRC )
+        TRANS_FLANK( &none &kp AMPS &kp DLLR &kp SEMI &kp PIPE    &kp UNDER &kp COLN &kp FSLH &kp BSLH &none )
                                                    &trans         &none            &trans               &trans         &trans
       &trans
       >;
@@ -64,9 +64,9 @@
       display-name = "navigate";
       bindings = <
         TRANS_ROW
-        ROW_TRANS( &kp PRCNT &kp KP_N7 &kp KP_N8 &kp KP_N9 &kp KP_PLUS    &kp PG_UP &kp HOME &kp UP &kp END &none )
-        ROW_TRANS( &kp KP_DOT &kp KP_N4 &kp KP_N5 &kp KP_N6 &kp KP_MINUS    &kp PG_DN &kp LEFT &kp DOWN &kp RIGHT &none )
-        ROW_TRANS( &kp KP_COMMA &kp KP_N1 &kp KP_N2 &kp KP_N3 &kp KP_MULTIPLY    &none &kp ASTRK &kp FSLH &kp PLUS &kp MINUS )
+        TRANS_FLANK( &kp PRCNT &kp KP_N7 &kp KP_N8 &kp KP_N9 &kp KP_PLUS    &kp PG_UP &kp HOME &kp UP &kp END &none )
+        TRANS_FLANK( &kp KP_DOT &kp KP_N4 &kp KP_N5 &kp KP_N6 &kp KP_MINUS    &kp PG_DN &kp LEFT &kp DOWN &kp RIGHT &none )
+        TRANS_FLANK( &kp KP_COMMA &kp KP_N1 &kp KP_N2 &kp KP_N3 &kp KP_MULTIPLY    &none &kp ASTRK &kp FSLH &kp PLUS &kp MINUS )
                                                    &kp KP_EQUAL   &kp KP_N0        &kp KP_DIVIDE        &trans         &none          &trans
       &trans
       >;
@@ -76,9 +76,9 @@
       display-name = "function";
       bindings = <
         TRANS_ROW
-        ROW_TRANS( &kp C_BRI_UP &kp F7 &kp F8 &kp F9 &kp F10    &none &none &none &none &none )
-        ROW_TRANS( &kp C_BRI_DN &kp F4 &kp F5 &kp F6 &kp F11    &kp LNLCK &kp CAPS &kp LSLCK &kp PSCRN &kp INS )
-        ROW_TRANS( &none &kp F1 &kp F2 &kp F3 &kp F12    &kp C_VOL_UP &kp C_VOL_DN &kp C_PP &kp C_NEXT &kp C_PREV )
+        TRANS_FLANK( &kp C_BRI_UP &kp F7 &kp F8 &kp F9 &kp F10    &none &none &none &none &none )
+        TRANS_FLANK( &kp C_BRI_DN &kp F4 &kp F5 &kp F6 &kp F11    &kp LNLCK &kp CAPS &kp LSLCK &kp PSCRN &kp INS )
+        TRANS_FLANK( &none &kp F1 &kp F2 &kp F3 &kp F12    &kp C_VOL_UP &kp C_VOL_DN &kp C_PP &kp C_NEXT &kp C_PREV )
                                                     &kp ESC        &trans           &trans               &none          &trans         &trans
       &trans
       >;
@@ -88,9 +88,9 @@
       display-name = "zmk";
       bindings = <
         TRANS_ROW
-        ROW_TRANS( &soft_off &out OUT_USB &out OUT_BLE &none &bt BT_CLR    &ext_power EP_TOG &trans &trans &none &soft_off )
-        ROW_TRANS( &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4    &none &none &none &none &none )
-        ROW_TRANS( &studio_unlock &none &bootloader &sys_reset &none    &none &sys_reset &bootloader &none &none )
+        TRANS_FLANK( &soft_off &out OUT_USB &out OUT_BLE &none &bt BT_CLR    &ext_power EP_TOG &trans &trans &none &soft_off )
+        TRANS_FLANK( &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4    &none &none &none &none &none )
+        TRANS_FLANK( &studio_unlock &none &bootloader &sys_reset &none    &none &sys_reset &bootloader &none &none )
                                                      &none           &trans           &tog 0               &trans            &trans         &none
 
       >;

--- a/config/qwerty/baseform.keymap
+++ b/config/qwerty/baseform.keymap
@@ -40,10 +40,10 @@
     qwerty_layer {
       display-name = "qwerty";
       bindings = <
-        TOP_ROW
-        ROW2( &hm RALT Q &kp W &kp E &kp R &kp T    &kp Y &kp U &kp I &kp O &kp P )
-        ROW3( &kp A &kp S &kp D &kp F &kp G    &kp H &kp J &kp K &kp L &hm RALT RET )
-        ROW4( &hm RCTRL Z &kp X &kp C &kp V &kp B    &kp N &kp M &kp COMMA &kp DOT &hm RCTRL APOS )
+        ROW4
+        ROW3( &hm RALT Q &kp W &kp E &kp R &kp T    &kp Y &kp U &kp I &kp O &kp P )
+        ROW2( &kp A &kp S &kp D &kp F &kp G    &kp H &kp J &kp K &kp L &hm RALT RET )
+        ROW1( &hm RCTRL Z &kp X &kp C &kp V &kp B    &kp N &kp M &kp COMMA &kp DOT &hm RCTRL APOS )
         THUMB_ROW
       >;
     };

--- a/config/shared_layers.dtsi
+++ b/config/shared_layers.dtsi
@@ -2,11 +2,10 @@
       display-name = "symbols";
       bindings = <
         TRANS_ROW
-        TRANS_FLANK( &kp PRCNT &kp CARET &kp GRAVE &kp TILDE &none    &none &kp LT &kp GT &kp LBKT &kp RBKT )
-        TRANS_FLANK( &kp HASH &kp AT &kp EXCL &kp QMARK &none    &kp EQUAL &kp LPAR &kp RPAR &kp LBRC &kp RBRC )
-        TRANS_FLANK( &none &kp AMPS &kp DLLR &kp SEMI &kp PIPE    &kp UNDER &kp COLN &kp FSLH &kp BSLH &none )
-                                                   &trans         &none            &trans               &trans         &trans
-      &trans
+        TRANS_FLANK( &kp PRCNT  &kp CARET  &kp GRAVE  &kp TILDE  &none      &none      &kp LT    &kp GT    &kp LBKT  &kp RBKT )
+        TRANS_FLANK( &kp HASH   &kp AT     &kp EXCL   &kp QMARK  &none      &kp EQUAL  &kp LPAR  &kp RPAR  &kp LBRC  &kp RBRC )
+        TRANS_FLANK( &none      &kp AMPS   &kp DLLR   &kp SEMI   &kp PIPE   &kp UNDER  &kp COLN  &kp FSLH  &kp BSLH  &none    )
+                                           &trans     &none      &trans     &trans     &trans    &trans
       >;
     };
 
@@ -14,12 +13,10 @@
       display-name = "navigate";
       bindings = <
         TRANS_ROW
-        TRANS_FLANK( &kp PRCNT &kp KP_N7 &kp KP_N8 &kp KP_N9 &kp KP_PLUS    &kp PG_UP &kp HOME &kp UP &kp END &none )
-        TRANS_FLANK( &kp KP_DOT &kp KP_N4 &kp KP_N5 &kp KP_N6 &kp KP_MINUS    &kp PG_DN &kp LEFT &kp DOWN &kp RIGHT &none )
-        TRANS_FLANK( &kp KP_COMMA &kp KP_N1 &kp KP_N2 &kp KP_N3 &kp KP_MULTIPLY    &none &kp ASTRK &kp FSLH &kp PLUS &kp MINUS )
-                                                   &kp KP_EQUAL   &kp KP_N0        &kp KP_DIVIDE        &trans         &none
-      &trans
-      &trans
+        TRANS_FLANK( &kp PRCNT     &kp KP_N7  &kp KP_N8  &kp KP_N9  &kp KP_PLUS        &kp PG_UP  &kp HOME   &kp UP    &kp END    &none     )
+        TRANS_FLANK( &kp KP_DOT    &kp KP_N4  &kp KP_N5  &kp KP_N6  &kp KP_MINUS       &kp PG_DN  &kp LEFT   &kp DOWN  &kp RIGHT  &none     )
+        TRANS_FLANK( &kp KP_COMMA  &kp KP_N1  &kp KP_N2  &kp KP_N3  &kp KP_MULTIPLY    &none      &kp ASTRK  &kp FSLH  &kp PLUS   &kp MINUS )
+                                              &kp KP_EQUAL &kp KP_N0 &kp KP_DIVIDE     &trans     &none      &trans 
       >;
     };
 
@@ -27,12 +24,10 @@
       display-name = "function";
       bindings = <
         TRANS_ROW
-        TRANS_FLANK( &kp C_BRI_UP &kp F7 &kp F8 &kp F9 &kp F10    &none &none &none &none &none )
-        TRANS_FLANK( &kp C_BRI_DN &kp F4 &kp F5 &kp F6 &kp F11    &kp LNLCK &kp CAPS &kp LSLCK &kp PSCRN &kp INS )
-        TRANS_FLANK( &none &kp F1 &kp F2 &kp F3 &kp F12    &kp C_VOL_UP &kp C_VOL_DN &kp C_PP &kp C_NEXT &kp C_PREV )
-                                                    &kp ESC        &trans           &trans               &none          &trans
-       &trans
-      &trans
+        TRANS_FLANK( &kp C_BRI_UP  &kp F7  &kp F8  &kp F9  &kp F10    &none         &none         &none      &none       &none      )
+        TRANS_FLANK( &kp C_BRI_DN  &kp F4  &kp F5  &kp F6  &kp F11    &kp LNLCK     &kp CAPS      &kp LSLCK  &kp PSCRN   &kp INS    )
+        TRANS_FLANK( &none         &kp F1  &kp F2  &kp F3  &kp F12    &kp C_VOL_UP  &kp C_VOL_DN  &kp C_PP   &kp C_NEXT  &kp C_PREV )
+                                           &kp ESC &trans  &trans     &none         &trans        &trans
       >;
     };
 
@@ -40,11 +35,10 @@
       display-name = "zmk";
       bindings = <
         TRANS_ROW
-        TRANS_FLANK( &soft_off &out OUT_USB &out OUT_BLE &none &bt BT_CLR    &ext_power EP_TOG &trans &trans &none &soft_off )
-        TRANS_FLANK( &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4    &none &none &none &none &none )
-        TRANS_FLANK( &studio_unlock &none &bootloader &sys_reset &none    &none &sys_reset &bootloader &none &none )
-                                                     &none           &trans           &tog 0               &trans
-                                                     &trans         &none
+        TRANS_FLANK( &soft_off       &out OUT_USB  &out OUT_BLE  &none         &bt BT_CLR     &ext_power EP_TOG &trans     &trans      &none &soft_off )
+        TRANS_FLANK( &bt BT_SEL 0    &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4   &none             &none      &none       &none &none     )
+        TRANS_FLANK( &studio_unlock  &none         &bootloader   &sys_reset    &none          &none             &sys_reset &bootloader &none &none     )
+                                                   &none         &trans        &tog 0         &trans            &trans     &none
       >;
     };
 

--- a/config/shared_layers.dtsi
+++ b/config/shared_layers.dtsi
@@ -1,0 +1,50 @@
+    symbols {
+      display-name = "symbols";
+      bindings = <
+        TRANS_ROW
+        TRANS_FLANK( &kp PRCNT &kp CARET &kp GRAVE &kp TILDE &none    &none &kp LT &kp GT &kp LBKT &kp RBKT )
+        TRANS_FLANK( &kp HASH &kp AT &kp EXCL &kp QMARK &none    &kp EQUAL &kp LPAR &kp RPAR &kp LBRC &kp RBRC )
+        TRANS_FLANK( &none &kp AMPS &kp DLLR &kp SEMI &kp PIPE    &kp UNDER &kp COLN &kp FSLH &kp BSLH &none )
+                                                   &trans         &none            &trans               &trans         &trans
+      &trans
+      >;
+    };
+
+    navigation {
+      display-name = "navigate";
+      bindings = <
+        TRANS_ROW
+        TRANS_FLANK( &kp PRCNT &kp KP_N7 &kp KP_N8 &kp KP_N9 &kp KP_PLUS    &kp PG_UP &kp HOME &kp UP &kp END &none )
+        TRANS_FLANK( &kp KP_DOT &kp KP_N4 &kp KP_N5 &kp KP_N6 &kp KP_MINUS    &kp PG_DN &kp LEFT &kp DOWN &kp RIGHT &none )
+        TRANS_FLANK( &kp KP_COMMA &kp KP_N1 &kp KP_N2 &kp KP_N3 &kp KP_MULTIPLY    &none &kp ASTRK &kp FSLH &kp PLUS &kp MINUS )
+                                                   &kp KP_EQUAL   &kp KP_N0        &kp KP_DIVIDE        &trans         &none
+      &trans
+      &trans
+      >;
+    };
+
+    function {
+      display-name = "function";
+      bindings = <
+        TRANS_ROW
+        TRANS_FLANK( &kp C_BRI_UP &kp F7 &kp F8 &kp F9 &kp F10    &none &none &none &none &none )
+        TRANS_FLANK( &kp C_BRI_DN &kp F4 &kp F5 &kp F6 &kp F11    &kp LNLCK &kp CAPS &kp LSLCK &kp PSCRN &kp INS )
+        TRANS_FLANK( &none &kp F1 &kp F2 &kp F3 &kp F12    &kp C_VOL_UP &kp C_VOL_DN &kp C_PP &kp C_NEXT &kp C_PREV )
+                                                    &kp ESC        &trans           &trans               &none          &trans
+       &trans
+      &trans
+      >;
+    };
+
+    meta {
+      display-name = "zmk";
+      bindings = <
+        TRANS_ROW
+        TRANS_FLANK( &soft_off &out OUT_USB &out OUT_BLE &none &bt BT_CLR    &ext_power EP_TOG &trans &trans &none &soft_off )
+        TRANS_FLANK( &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3 &bt BT_SEL 4    &none &none &none &none &none )
+        TRANS_FLANK( &studio_unlock &none &bootloader &sys_reset &none    &none &sys_reset &bootloader &none &none )
+                                                     &none           &trans           &tog 0               &trans
+                                                     &trans         &none
+      >;
+    };
+


### PR DESCRIPTION
## Summary
- add `config/keymap_edges.dtsi` to define common row/ thumb macros
- refactor QWERTY, Colemak, and Dvorak base layers to use new macros

## Testing
- `west build -p -b nice_nano_v2 zmk/app -d build/qwerty -- -DZMK_CONFIG=../config/qwerty` *(failed: Could not find a package configuration file provided by "Zephyr-sdk")*
- `west build -p -b nice_nano_v2 zmk/app -d build/colemak -- -DZMK_CONFIG=../config/colemak` *(failed: Could not find a package configuration file provided by "Zephyr-sdk")*
- `west build -p -b nice_nano_v2 zmk/app -d build/dvorak -- -DZMK_CONFIG=../config/dvorak` *(failed: Could not find a package configuration file provided by "Zephyr-sdk")*

------
https://chatgpt.com/codex/tasks/task_e_68ae5f3e5b8c8324a33b496b18cc8c53