### PR TITLE
docs: add keymaps image to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@
 
 [Learn about the Baseform Keyboard here](https://posture.works/baseform/)
 
+![Keymaps](https://posture.works/wp-content/uploads/2025/08/Keymaps-Narrow.png)


### PR DESCRIPTION
## Summary
- add link to keymaps image at end of README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afcc7b0b088324a7a25fffe4289900