### PR TITLE
docs: embed keymaps image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@
 
 [Learn about the Baseform Keyboard here](https://posture.works/baseform/)
 
+<img src="https://posture.works/wp-content/uploads/2025/08/Keymaps-Narrow.png" alt="Keymaps" />


### PR DESCRIPTION
## Summary
- embed keymaps image in README using HTML tag

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afcc7b0b088324a7a25fffe4289900