### PR TITLE
docs: add keymap images to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,6 @@
 
 [Learn about the Baseform Keyboard here](https://posture.works/baseform/)
 
+![Keymaps Base Layers](https://posture.works/wp-content/uploads/2025/08/Keymaps-Base-Layers-Narrow.jpg)
+![Keymaps Shared Layers](https://posture.works/wp-content/uploads/2025/08/Keymaps-Shared-Layers-Narrow.jpg)
+


### PR DESCRIPTION
## Summary
- embed images showing base and shared keymap layers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b425e45db48324aaa042b938983e19