### PR TITLE
Add WS2812 LED support for baseform shield

### DIFF
--- a/boards/shields/baseform/Kconfig.defconfig
+++ b/boards/shields/baseform/Kconfig.defconfig
@@ -36,6 +36,9 @@ if SHIELD_BASEFORM_TRIO_BASE_CENTRAL || SHIELD_BASEFORM_TRIO_LEFT_PERIPHERAL || 
 config ZMK_SPLIT
     default y
 
+config ZMK_RGB_UNDERGLOW
+    default y
+
 endif # split
 
 # -------------------------

--- a/boards/shields/baseform/baseform.dtsi
+++ b/boards/shields/baseform/baseform.dtsi
@@ -15,15 +15,12 @@
         zephyr,display = &oled;
         zmk,physical-layout = &baseform_6x4_lo;
         zmk,studio-rpc-uart = &uart1;
+        zmk,underglow = &led_strip;
     };
 
-    aliases {
-        led-strip = &ws2812;
-    };
-
-    ws2812: ws2812 {
+    led_strip: ws2812 {
         compatible = "worldsemi,ws2812-gpio";
-        status = "okay";
+        label = "WS2812";
         chain-length = <1>;
         color-mapping = <LED_COLOR_ID_GREEN LED_COLOR_ID_RED LED_COLOR_ID_BLUE>;
         in-gpios = <&gpio0 22 GPIO_ACTIVE_HIGH>;

--- a/boards/shields/baseform/baseform.dtsi
+++ b/boards/shields/baseform/baseform.dtsi
@@ -26,7 +26,7 @@
         status = "okay";
         chain-length = <1>;
         color-mapping = <LED_COLOR_ID_GREEN LED_COLOR_ID_RED LED_COLOR_ID_BLUE>;
-        data-gpios = <&gpio0 22 GPIO_ACTIVE_HIGH>;
+        in-gpios = <&gpio0 22 GPIO_ACTIVE_HIGH>;
     };
 
     baseform_6x4_lo: baseform_6x4_lo {

--- a/boards/shields/baseform/baseform.dtsi
+++ b/boards/shields/baseform/baseform.dtsi
@@ -5,14 +5,28 @@
  */
 
 #include <dt-bindings/zmk/matrix_transform.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/led/led.h>
 #include <physical_layouts.dtsi>
 
 / {
 
     chosen {
         zephyr,display = &oled;
-	zmk,physical-layout = &baseform_6x4_lo;
-	zmk,studio-rpc-uart = &uart1;
+        zmk,physical-layout = &baseform_6x4_lo;
+        zmk,studio-rpc-uart = &uart1;
+    };
+
+    aliases {
+        led-strip = &ws2812;
+    };
+
+    ws2812: ws2812 {
+        compatible = "worldsemi,ws2812-gpio";
+        status = "okay";
+        chain-length = <1>;
+        color-mapping = <LED_COLOR_ID_GREEN LED_COLOR_ID_RED LED_COLOR_ID_BLUE>;
+        data-gpios = <&gpio0 22 GPIO_ACTIVE_HIGH>;
     };
 
     baseform_6x4_lo: baseform_6x4_lo {

--- a/boards/shields/baseform/baseform.zmk.yml
+++ b/boards/shields/baseform/baseform.zmk.yml
@@ -4,10 +4,11 @@ name: baseform
 type: shield
 url: https://github.com/hmngwy/baseform
 requires: [nice_nano_v2]
-exposes: [i2c_oled]
+exposes: [i2c_oled, underglow]
 features:
   - keys
   - display
+  - underglow
   - studio
 siblings:
   - baseform_left


### PR DESCRIPTION
## Summary
- add a devicetree node for a single WS2812 LED on GPIO P0.22 and expose it through an alias
- advertise the underglow capability in the shield metadata
- enable RGB underglow by default for all baseform shield variants

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ecc7431e948324b0ea45437b0a39b7